### PR TITLE
MySQL 5.7 by default has case-sensitive tables.  Lowercase the last "…

### DIFF
--- a/MySQL_5_6/create_tables.sql
+++ b/MySQL_5_6/create_tables.sql
@@ -309,17 +309,17 @@ CREATE TABLE `OACCDB`.`OAC_ResourcePassword` (
 );
 
 # ---------------------------------------------------------------------- #
-# Add table "OACCDB.OAC_ResourceExternalID"                              #
+# Add table "OACCDB.OAC_ResourceExternalId"                              #
 # ---------------------------------------------------------------------- #
 
-CREATE TABLE `OACCDB`.`OAC_ResourceExternalID` (
+CREATE TABLE `OACCDB`.`OAC_ResourceExternalId` (
     `ResourceID` BIGINT NOT NULL,
     `ExternalID` VARCHAR(255) NOT NULL,
     CONSTRAINT `PK_RE` PRIMARY KEY (`ResourceID`),
     CONSTRAINT `UX_ExternalID` UNIQUE (`ExternalID`)
 );
 
-CREATE INDEX `IX_RE_ExternalID` ON `OACCDB`.`OAC_ResourceExternalID` (`ExternalID`);
+CREATE INDEX `IX_RE_ExternalID` ON `OACCDB`.`OAC_ResourceExternalId` (`ExternalID`);
 
 # ---------------------------------------------------------------------- #
 # Foreign key constraints                                                #
@@ -442,5 +442,5 @@ ALTER TABLE `OACCDB`.`OAC_Grant_DomCrPerm_Sys` ADD CONSTRAINT `GrDCrPSys_R_Grant
 ALTER TABLE `OACCDB`.`OAC_ResourcePassword` ADD CONSTRAINT `RP_R_ResourceID` 
     FOREIGN KEY (`ResourceID`) REFERENCES `OACCDB`.`OAC_Resource` (`ResourceID`);
 
-ALTER TABLE `OACCDB`.`OAC_ResourceExternalID` ADD CONSTRAINT `RE_R_ResourceID` 
+ALTER TABLE `OACCDB`.`OAC_ResourceExternalId` ADD CONSTRAINT `RE_R_ResourceID` 
     FOREIGN KEY (`ResourceID`) REFERENCES `OACCDB`.`OAC_Resource` (`ResourceID`);

--- a/MySQL_5_6/drop_tables.sql
+++ b/MySQL_5_6/drop_tables.sql
@@ -109,21 +109,21 @@ ALTER TABLE `OACCDB`.`OAC_Grant_DomCrPerm_Sys` DROP FOREIGN KEY `GrDCrPSys_R_Gra
 
 ALTER TABLE `OACCDB`.`OAC_ResourcePassword` DROP FOREIGN KEY `RP_R_ResourceID`;
 
-ALTER TABLE `OACCDB`.`OAC_ResourceExternalID` DROP FOREIGN KEY `RE_R_ResourceID`;
+ALTER TABLE `OACCDB`.`OAC_ResourceExternalId` DROP FOREIGN KEY `RE_R_ResourceID`;
 
 # ---------------------------------------------------------------------- #
-# Drop table "OACCDB.OAC_ResourceExternalID"                             #
+# Drop table "OACCDB.OAC_ResourceExternalId"                             #
 # ---------------------------------------------------------------------- #
 
 # Drop constraints #
 
-ALTER TABLE `OACCDB`.`OAC_ResourceExternalID` DROP PRIMARY KEY;
+ALTER TABLE `OACCDB`.`OAC_ResourceExternalId` DROP PRIMARY KEY;
 
-DROP INDEX `UX_ExternalID` ON `OACCDB`.`OAC_ResourceExternalID`;
+DROP INDEX `UX_ExternalID` ON `OACCDB`.`OAC_ResourceExternalId`;
 
 # Drop table #
 
-DROP TABLE `OACCDB`.`OAC_ResourceExternalID`;
+DROP TABLE `OACCDB`.`OAC_ResourceExternalId`;
 
 # ---------------------------------------------------------------------- #
 # Drop table "OACCDB.OAC_ResourcePassword"                               #


### PR DESCRIPTION
…d" in OAC_ResourceExternalId to match the OACC Java code.